### PR TITLE
feature/#5-IStringable-to-log IStringable в лог

### DIFF
--- a/Sdk/Core/Types/ICloneable.h
+++ b/Sdk/Core/Types/ICloneable.h
@@ -10,7 +10,7 @@ namespace energy { namespace core { namespace types {
  * T - тип, в который может быть клонирован исходный тип. Для типа T должен быть доступен конструктор копирования.
  */
 template<typename T>
-class SDKSHARED_EXPORT ICloneable {
+class ICloneable {
 public:
     ICloneable() = default;
     virtual ~ICloneable() = default;

--- a/Sdk/Core/Types/IStringable.h
+++ b/Sdk/Core/Types/IStringable.h
@@ -9,7 +9,7 @@ namespace energy { namespace core { namespace types {
 /**
  * @brief IStringable интерфейс, реализации которого должны уметь предоставлять свое значение в виде строки
  */
-class SDKSHARED_EXPORT IStringable {
+class IStringable {
 public:
     IStringable() = default;
     virtual ~IStringable() = default;

--- a/Sdk/Database/IDatabaseConnectionSettings.h
+++ b/Sdk/Database/IDatabaseConnectionSettings.h
@@ -14,7 +14,7 @@ class IDatabaseConnectionSettings :
 {
 public:
     IDatabaseConnectionSettings() = default;
-    virtual ~IDatabaseConnectionSettings() = default;
+    virtual ~IDatabaseConnectionSettings() override = default;
 };
 
 } }

--- a/Sdk/Logs/ILogger.cpp
+++ b/Sdk/Logs/ILogger.cpp
@@ -7,3 +7,28 @@ ILogger::ILogger(const ILogMessageFormatter *messageFormatter) :
 {
 
 }
+
+void ILogger::info(const energy::core::types::IStringable &stringable)
+{
+    info(stringable.toString().c_str());
+}
+
+void ILogger::debug(const energy::core::types::IStringable &stringable)
+{
+    debug(stringable.toString().c_str());
+}
+
+void ILogger::warning(const energy::core::types::IStringable &stringable)
+{
+    warning(stringable.toString().c_str());
+}
+
+void ILogger::error(const energy::core::types::IStringable &stringable)
+{
+    error(stringable.toString().c_str());
+}
+
+void ILogger::trace(const energy::core::types::IStringable &stringable)
+{
+    trace(stringable.toString().c_str());
+}

--- a/Sdk/Logs/ILogger.h
+++ b/Sdk/Logs/ILogger.h
@@ -1,6 +1,7 @@
 #ifndef ILOGGER_H
 #define ILOGGER_H
 
+#include <Sdk/Core/Types/IStringable.h>
 #include <Sdk/Logs/ILogMessageFormatter.h>
 
 namespace energy::logs {
@@ -8,7 +9,7 @@ namespace energy::logs {
 /**
  * @brief Интерфейс для классов, выполняющих логирование.
  */
-class ILogger
+class SDKSHARED_EXPORT ILogger
 {
 public:
     ILogger(const ILogMessageFormatter *messageFormatter);
@@ -16,13 +17,56 @@ public:
 
     /**
      * @brief Логирование в информационный канал
-     * @param message
+     * @param message Сообщение
      */
     virtual void info(const char *message) = 0;
+    /**
+     * @brief Логирование в информационный канал
+     * @param message Объект, преобразуемые в строку
+     */
+    virtual void info(const energy::core::types::IStringable &stringable);
+
+    /**
+     * @brief Логирование в канал для дебага
+     * @param message Сообщение
+     */
     virtual void debug(const char *message) = 0;
+    /**
+     * @brief Логирование в канал для дебага
+     * @param message Объект, преобразуемые в строку
+     */
+    virtual void debug(const energy::core::types::IStringable &stringable);
+
+    /**
+     * @brief Логирование в канал предупреждений
+     * @param message Сообщение
+     */
     virtual void warning(const char *message) = 0;
+    /**
+     * @brief Логирование в канал предупреждений
+     * @param message Объект, преобразуемые в строку
+     */
+    virtual void warning(const energy::core::types::IStringable &stringable);
+    /**
+     * @brief Логирование в канал ошибок
+     * @param message Сообщение
+     */
     virtual void error(const char *message) = 0;
+    /**
+     * @brief Логирование в канал ошибок
+     * @param message Объект, преобразуемые в строку
+     */
+    virtual void error(const energy::core::types::IStringable &stringable);
+    /**
+     * @brief Логирование в канал трассировки
+     * @param message Сообщение
+     */
     virtual void trace(const char *message) = 0;
+    /**
+     * @brief Логирование в канал трассировки
+     * @param message Объект, преобразуемые в строку
+     */
+    virtual void trace(const energy::core::types::IStringable &stringable);
 
 protected:
     const ILogMessageFormatter *_messageFormatter;

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -106,7 +106,7 @@ int main()
         connectionSettings.setDatabase("EnergyExpert");
         connectionSettings.setUsername("postgres");
         connectionSettings.setPassword("123456");
-        consoleLogger.debug(connectionSettings.toString().c_str());
+        consoleLogger.ILogger::debug(connectionSettings);
 
         IDatabaseConnection *connection = new PostgreSqlConnection();
         connection->setConnectionSettings(&connectionSettings);


### PR DESCRIPTION
Добавлены методы, принимающие в качетсве параметра IStringable. Реализованы в классе ILogger.
Использовать в наследниках через прямой вызов родительского метода.